### PR TITLE
Add DmxManager (ArtNet) and update WifiManager to use Persistence pointer; integrate into main loop

### DIFF
--- a/lib/DmxManager/DmxManager.cpp
+++ b/lib/DmxManager/DmxManager.cpp
@@ -1,0 +1,42 @@
+#include "DmxManager.h"
+
+DmxManager *DmxManager::instance = nullptr;
+
+DmxManager::DmxManager(Persistence *persistentDataIn) {
+    persistentData = persistentDataIn;
+    instance = this;
+}
+
+void DmxManager::init() {
+    artnet.begin();
+    artnet.setArtDmxCallback(onDmxFrameProxy);
+}
+
+void DmxManager::loopHandler() {
+    artnet.read();
+}
+
+void DmxManager::onDmxFrameProxy(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data, IPAddress remoteIP) {
+    (void) remoteIP;
+    if (instance != nullptr) {
+        instance->onDmxFrame(universe, length, sequence, data);
+    }
+}
+
+void DmxManager::onDmxFrame(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data) {
+    (void) sequence;
+
+    if (universe != DMX_UNIVERSE || data == nullptr) {
+        return;
+    }
+
+    const uint8_t startIndex = DMX_START_CHANNEL - 1;
+    if (length <= startIndex + 2) {
+        return;
+    }
+
+    persistentData->lock();
+    persistentData->idleColor = Color(data[startIndex], data[startIndex + 1], data[startIndex + 2]);
+    persistentData->touch = false;
+    persistentData->unlock();
+}

--- a/lib/DmxManager/DmxManager.h
+++ b/lib/DmxManager/DmxManager.h
@@ -1,0 +1,25 @@
+#ifndef FURSUITAUGEN_NEOPIXEL_BOOPABLE_NOSE_DMXMANAGER_H
+#define FURSUITAUGEN_NEOPIXEL_BOOPABLE_NOSE_DMXMANAGER_H
+
+#include "ArtnetWifi.h"
+#include "../helperStructures.h"
+
+class DmxManager {
+public:
+    explicit DmxManager(Persistence *persistentDataIn);
+    void init();
+    void loopHandler();
+
+private:
+    static constexpr uint16_t DMX_UNIVERSE = 0;
+    static constexpr uint8_t DMX_START_CHANNEL = 1;
+
+    Persistence *persistentData;
+    ArtnetWifi artnet;
+
+    void onDmxFrame(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data);
+    static void onDmxFrameProxy(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *data, IPAddress remoteIP);
+    static DmxManager *instance;
+};
+
+#endif //FURSUITAUGEN_NEOPIXEL_BOOPABLE_NOSE_DMXMANAGER_H

--- a/lib/WifiManager/WifiManager.cpp
+++ b/lib/WifiManager/WifiManager.cpp
@@ -3,13 +3,14 @@
 //
 
 #include "WifiManager.h"
-WifiManager::WifiManager() {
 
+WifiManager::WifiManager(Persistence *persistentDataIn) {
+    persistentData = persistentDataIn;
 }
 
 void WifiManager::init() {
     WiFi.mode(WIFI_MODE_AP);
-    WiFi.softAP(persistentData.ssid,persistentData.appw);
+    WiFi.softAP(persistentData->ssid, persistentData->appw);
 }
 
 void WifiManager::loopHandler() {

--- a/lib/WifiManager/WifiManager.h
+++ b/lib/WifiManager/WifiManager.h
@@ -10,11 +10,12 @@
 
 class WifiManager {
 public:
-    WifiManager();
+    explicit WifiManager(Persistence *persistentDataIn);
     void init();
     void loopHandler();
+
 private:
-    Persistence persistentData;
+    Persistence *persistentData;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@ using namespace std;
 #include <Arduino.h>
 #include <WebsiteController.h>
 #include <WifiManager.h>
+#include "../lib/DmxManager/DmxManager.h"
 #include "../lib/BoardPinMapping.h"
 
 #include "../lib/FanController/FanController.h"
@@ -31,6 +32,7 @@ TouchHandler *touchHandler;
 NeopixelAnimator *animator;
 WebsiteController *website;
 WifiManager *wifi;
+DmxManager *dmx;
 PersistentStorage *storage;
 ButtonHandler *button;
 FanController *fan;
@@ -39,7 +41,8 @@ Persistence persistentData;
 
 void createAllObjects() {
     touchHandler = new TouchHandler(NOSE_BOOP_PIN, &persistentData);
-    wifi = new WifiManager();
+    wifi = new WifiManager(&persistentData);
+    dmx = new DmxManager(&persistentData);
     //ledManager = new NeoPixelManager(STRIPDATAPIN, PIXELCOUNT,1000);
     ledManager = new RGBStripManager(LED_RED_PIN,LED_GREEN_PIN,LED_BLUE_PIN,5000,true);
     website = new WebsiteController(&persistentData);
@@ -58,8 +61,9 @@ void initAll() {
         fan->init();
     }
     Serial.println(persistentData.configMode);
+    wifi->init();
+    dmx->init();
     if (persistentData.configMode) {
-        wifi->init();
         website->init();
     }
     animator->init();
@@ -80,8 +84,9 @@ void loopHandlers() {
     if (fan != nullptr) {
         fan->loopHandler();
     }
+    wifi->loopHandler();
+    dmx->loopHandler();
     if (persistentData.configMode) {
-        wifi->loopHandler();
         website->loopHandler();
     }
     if (persistentData.savePersistentToEMMC) {


### PR DESCRIPTION
### Motivation
- Introduce ArtNet/DMX support to allow external DMX controllers to set the device idle color and clear touch state.
- Make `WifiManager` use the shared `Persistence` instance to read SSID/password and unify lifetime management.
- Wire the new DMX manager and updated WiFi handling into the main application lifecycle.

### Description
- Added `lib/DmxManager/DmxManager.h` and `lib/DmxManager/DmxManager.cpp` which implement an `ArtnetWifi`-backed `DmxManager` that listens to a configured DMX universe and writes received RGB values into `Persistence::idleColor` while using `Persistence::lock()`/`unlock()`.
- Changed `WifiManager` constructor signature to `WifiManager(Persistence *persistentDataIn)` and store a `Persistence *persistentData` pointer in the class, and updated `WifiManager::init()` to use `persistentData->ssid` and `persistentData->appw`.
- Updated `src/main.cpp` to instantiate `WifiManager` and `DmxManager` with `&persistentData`, call `wifi->init()` and `dmx->init()` during initialization, and invoke `wifi->loopHandler()` and `dmx->loopHandler()` in the main loop while keeping `website->loopHandler()` gated by `configMode`.

### Testing
- Compiled the firmware (Arduino/embedded build) after the changes, and the build completed successfully.
- No automated unit tests were present for these modules, so no unit test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ee5fb6c833092b7fdb38e616298)